### PR TITLE
Add config for continuing to run with an empty queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Environment Variables and defaults are loaded from `config/sqsd-default-config.g
 | `SQSD_QUEUE_URL`                        | -                  | if `SQSD_QUEUE_NAME` not specified | Your queue URL. You can instead use the queue name but this takes precedence over queue name. |
 | `SQSD_QUEUE_NAME`                       | -                  | if `SQSD_QUEUE_URL` not specified  | Your queue name.                                                                              |
 | `SQSD_MAX_MESSAGES_PER_REQUEST`         | `10` (max: `10`)   | no                                 | Max number of messages to retrieve per request.                                               |
+| `SQSD_RUN_DAEMONIZED`                   | `0`                | no                                 | Whether to continue running with empty queue (0 is no, 1 is yes)
+| `SQSD_SLEEP_SECONDS`                    | `0`                | no                                 | Number of seconds to wait after polling empty queue when daemonized
 | `SQSD_WAIT_TIME_SECONDS`                | `20` (max: `20`)   | no                                 | Long polling wait time when querying the queue.                                               |
 | `SQSD_WORKER_HTTP_HOST`                 | `http://127.0.0.1` | yes                                | Host address to your service.                                                                 |
 | `SQSD_WORKER_HTTP_PATH`                 | `/`                | yes                                | Your service endpoint/path where to POST the messages.                                        |

--- a/src/config/sqsd-config.groovy
+++ b/src/config/sqsd-config.groovy
@@ -10,6 +10,8 @@
 //sqsd.queue.url = url of the aws sqs queue (Required)
 //sqsd.queue.region_name = region name of the aws sqs queue
 //sqsd.max_messages_per_request = messages to retrieve per request (max: 10)
+//sqsd.run_daemonized = set to 1 to run daemonized (0 to stop after queue is empty)
+//sqsd.sleep_seconds = number of seconds to wait after polling empty queue when daemonized
 //sqsd.wait_time_seconds = long polling wait time when querying the queue (max: 20)
 //sqsd.worker.http.host = the host url where to POST the retrieved messages
 //sqsd.worker.http.path = the path of the host's enpoint where to POST the retrieved messages

--- a/src/config/sqsd-default-config.groovy
+++ b/src/config/sqsd-default-config.groovy
@@ -16,6 +16,8 @@ sqsd.queue.name = System.getenv("SQSD_QUEUE_NAME")
 sqsd.queue.url = System.getenv("SQSD_QUEUE_URL")
 sqsd.queue.region_name = System.getenv("SQS_QUEUE_REGION_NAME") ?: "us-east-1"
 sqsd.max_messages_per_request = System.getenv("SQSD_MAX_MESSAGES_PER_REQUEST") as Integer ?: 10 // range: 1-10
+sqsd.run_daemonized = System.getenv("SQSD_RUN_DAEMONIZED") as Integer ?: 0 // 0 or 1
+sqsd.sleep_seconds = System.getenv("SQSD_SLEEP_SECONDS") as Integer ?: 0
 sqsd.wait_time_seconds = System.getenv("SQSD_WAIT_TIME_SECONDS") as Integer ?: 20 // range: 1-20
 
 /**

--- a/src/sqsd.groovy
+++ b/src/sqsd.groovy
@@ -68,8 +68,11 @@ try {
         def messages = sqs.receiveMessage(receiveMessageRequest).getMessages()
         println "Received Messages : " + messages.size()
 
-        // Break when empty
-        if(messages.size() <= 0) break
+        // Break when empty if not running daemonized
+        if(messages.size() <= 0) {
+            if (config.sqsd.run_daemonized < 1) break
+            else if(config.sqsd.sleep_seconds) sleep(config.sqsd.sleep_seconds * 1000) // don't want to hammer implementations that don't implement long-polling
+        }
 
         for (Message message : messages) { // TODO: Make async.
             if(handleMessage(


### PR DESCRIPTION
Here's my go at fixing #3.

One thing I'm not entirely happy about is this hammers SQS APIs that don't implement long polling like the fake-sqs I use.
