### PR TITLE
Add Shebang line

### DIFF
--- a/src/sqsd.groovy
+++ b/src/sqsd.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 /**
  * <h1>SQSD</h1>
  * sqsd : A simple alternative to the Amazon SQS Daemon ("sqsd") used on AWS Beanstalk worker tier instances.


### PR DESCRIPTION
According to [this](http://docs.groovy-lang.org/docs/groovy-latest/html/documentation/#_shebang_line) you can add a Shebang line (`#!/usr/bin/env groovy`)  usewill search your path looking for groovy and allows scripts to be run directly from the command-line.
