### PR TITLE
Let the AWS SDK figure out credentials

### DIFF
--- a/src/sqsd.groovy
+++ b/src/sqsd.groovy
@@ -40,15 +40,12 @@ if (customConfigFile.exists()) {
 }
 
 // Assert that all required properties are provided.
-assert config.aws.access_key_id != null, "Required `aws.access_key_id` property not provided!!"
-assert config.aws.secret_access_key != null, "Required `aws.secret_access_key` property not provided!!"
 assert config.sqsd.queue.url != null || config.sqsd.queue.name != null, "Required `sqsd.queue.url` OR `sqsd.queue.name` property not provided!!"
 assert config.sqsd.worker.http.host != null, "Required `sqsd.worker.http.host` property not provided!!"
 assert config.sqsd.worker.http.path != null, "Required `sqsd.worker.http.path` property not provided!!"
 
 // Setup sqs client.
-def awsCreds = new BasicAWSCredentials(config.aws.access_key_id as String, config.aws.secret_access_key as String) // TODO: Determine if this is the correct approach when using Docker.
-def sqs = new AmazonSQSClient(awsCreds)
+def sqs = new AmazonSQSClient()
 def sqsRegion = Region.getRegion(Regions.fromName(config.sqsd.queue.region_name as String))
 sqs.setRegion(sqsRegion)
 String sqsQueueUrl = config.sqsd.queue.url ?: sqs.getQueueUrl(config.sqsd.queue.name as String).getQueueUrl() // Use provided queue url or name (url has priority)

--- a/src/sqsd.groovy
+++ b/src/sqsd.groovy
@@ -62,9 +62,8 @@ try {
 
     // Consume queue until empty
     while(true){ // TODO: Limit the amount of messages to process using a property.
-        println "Querying SQS for messages ..."
         def messages = sqs.receiveMessage(receiveMessageRequest).getMessages()
-        println "Received Messages : " + messages.size()
+        println "Queried SQS, received " + messages.size() + " messages."
 
         // Break when empty if not running daemonized
         if(messages.size() <= 0) {
@@ -91,14 +90,12 @@ try {
                 sqs.changeMessageVisibility(new ChangeMessageVisibilityRequest(sqsQueueUrl, messageReceiptHandle, 0))
             }
         }
-
-        println "Done!!"
     }
 }
 catch (AmazonServiceException ase) { ase.printStackTrace() } // TODO: Add log4j or something similar.
 catch (AmazonClientException ace) { ace.printStackTrace() }
 
-println "SQSD finished successfully!"
+println "SQSD exiting successfully!"
 
 def handleMessage(String httpHost, String httpPath, String contentType, Message message){
     def slurper = new JsonSlurper().setType(JsonParserType.LAX)


### PR DESCRIPTION
not specifying credentials at all lets the AWS sdk figure out the credentials on its own, which will work with setting key id and secret key as environment variables, but it will also work on EC2 instances that have an IAM Role set - the SDK will automatically pick up the ever-changing keys from the role.

Optionally, the credentials in the config could still be usable, but they shouldn't have a default and shouldn't be required - for our uses this is not necessary though.

Also, implemented giving failed messages back to the queue and made logging a little less verbose
